### PR TITLE
fix: 修复 Invalid Parameter 的问题

### DIFF
--- a/fastlane-plugin-bearychat/lib/fastlane/plugin/bearychat/actions/bearychat_action.rb
+++ b/fastlane-plugin-bearychat/lib/fastlane/plugin/bearychat/actions/bearychat_action.rb
@@ -33,48 +33,44 @@ module Fastlane
       end
 
       def self.available_options
-        [
-          FastlaneCore::ConfigItem.new(key: :webhook,
-                                  env_name: "BEARYCHAT_WEBHOOK",
-                               description: "A description of your option",
-                                  optional: false,
-                                      type: String)
-
-          FastlaneCore::ConfigItem.new(key: :text,
-                                  env_name: "BEARYCHAT_TEXT",
-                               description: "A description of your option",
-                                  optional: false,
-                                      type: String)
-
-          FastlaneCore::ConfigItem.new(key: :notification,
-                                  env_name: "BEARYCHAT_NOTIFICATION",
-                               description: "A description of your option",
-                                  optional: true,
-                                      type: String)
-          FastlaneCore::ConfigItem.new(key: :markdown,
-                                  env_name: "BEARYCHAT_MARKDOWN",
-                               description: "A description of your option",
-                                  optional: true,
-                                      type: Boolean)
-
-          FastlaneCore::ConfigItem.new(key: :channel,
-                                  env_name: "BEARYCHAT_CHANNEL",
-                               description: "A description of your option",
-                                  optional: true,
-                                      type: String)
-
-          FastlaneCore::ConfigItem.new(key: :user,
-                                  env_name: "BEARYCHAT_USER",
-                               description: "A description of your option",
-                                  optional: true,
-                                      type: String)
-
-          FastlaneCore::ConfigItem.new(key: :attachments,
-                                  env_name: "BEARYCHAT_ATTACHMENTS",
-                               description: "A description of your option",
-                                  optional: true,
-                                      type: Hash)
-        ]
+        FastlaneCore::CommanderGenerator.new.generate(
+            [
+                FastlaneCore::ConfigItem.new(key:         :webhook,
+                                             env_name:    "BEARYCHAT_WEBHOOK",
+                                             description: "A description of your option",
+                                             is_string:   true,
+                                             optional:    false),
+                FastlaneCore::ConfigItem.new(key:         :text,
+                                             env_name:    "BEARYCHAT_TEXT",
+                                             description: "A description of your option",
+                                             is_string:   true,
+                                             optional:    false),
+                FastlaneCore::ConfigItem.new(key:         :notification,
+                                             env_name:    "BEARYCHAT_NOTIFICATION",
+                                             description: "A description of your option",
+                                             is_string:   false,
+                                             optional:    true),
+                FastlaneCore::ConfigItem.new(key:         :markdown,
+                                             env_name:    "BEARYCHAT_MARKDOWN",
+                                             description: "A description of your option",
+                                             is_string:   false,
+                                             optional:    true),
+                FastlaneCore::ConfigItem.new(key:         :channel,
+                                             env_name:    "BEARYCHAT_CHANNEL",
+                                             description: "A description of your option",
+                                             is_string:   true,
+                                             optional:    true),
+                FastlaneCore::ConfigItem.new(key:         :user,
+                                             env_name:    "BEARYCHAT_USER",
+                                             description: "A description of your option",
+                                             is_string:   true,
+                                             optional:    true),
+                FastlaneCore::ConfigItem.new(key:         :attachments,
+                                             env_name:    "BEARYCHAT_ATTACHMENTS",
+                                             description: "A description of your option",
+                                             is_string:   false,
+                                             optional:    true)
+            ])
       end
 
       def self.is_supported?(platform)

--- a/fastlane-plugin-bearychat/lib/fastlane/plugin/bearychat/actions/bearychat_action.rb
+++ b/fastlane-plugin-bearychat/lib/fastlane/plugin/bearychat/actions/bearychat_action.rb
@@ -2,16 +2,25 @@ module Fastlane
   module Actions
     class BearychatAction < Action
       def self.run(params)
+        require 'json'
 
         uri = URI.parse(params[:webhook])
 
         postParams = {
-            "text" => params[:text],
-            "markdown" => params[:markdown],
-            "channel" => params[:channel],
+            "text"        => params[:text],
+            "markdown"    => params[:markdown],
+            "channel"     => params[:channel],
             "attachments" => params[:attachments]
         }
-        res = Net::HTTP.post_form(uri, postParams)
+
+        request              = Net::HTTP::Post.new(uri)
+        request.body         = postParams.to_json
+        request.content_type = 'application/json'
+
+        res = Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') { |http|
+          http.request(request)
+        }
+
         puts res
       end
 


### PR DESCRIPTION
1. 修复 fastlane 接口错误的问题 (self.available_options 要使用 FastlaneCore::CommanderGenerator.new.generate 去生成)
2. 修复 option 缺少 isString 字段导致的 Invalid Parameter 错误
3. 修复 BearyChat 的请求 Content-Type 错误以及没有使用 json 编码的错误